### PR TITLE
Fix: Panic (from IP.Parse())

### DIFF
--- a/collector/rbl.go
+++ b/collector/rbl.go
@@ -146,7 +146,15 @@ func (rbl *Rbl) lookup(rblList string, targetHost string) []Rblresult {
 		res.Address = ip
 		res.Rbl = rblList
 
-		revIP := godnsbl.Reverse(net.ParseIP(ip))
+		// attempt to "validate" the IP
+		ValidIPAddress := net.ParseIP(ip)
+		if ValidIPAddress == nil {
+			log.Errorf("Unable to parse IP: %s", ip)
+			continue
+		}
+
+		// reverse it, for the look up
+		revIP := godnsbl.Reverse(ValidIPAddress)
 
 		rbl.query(revIP, rblList, &res)
 

--- a/collector/rbl.go
+++ b/collector/rbl.go
@@ -61,6 +61,8 @@ func (rbl *Rbl) makeQuery(msg *dns.Msg) (*dns.Msg, error) {
 	return result, err
 }
 
+// leaving this note for future me: maybe asking for As is not enough?
+// what about CNAMEs, or AAAAs, etc..
 func (rbl *Rbl) getARecords(target string) ([]string, error) {
 	msg := rbl.createQuestion(target, dns.TypeA)
 
@@ -131,7 +133,7 @@ func (rbl *Rbl) lookup(rblList string, targetHost string) []Rblresult {
 	if addr == nil {
 		ipsA, err := rbl.getARecords(targetHost)
 		if err != nil {
-			log.Debugln(err)
+			log.Errorln(err)
 		}
 
 		ips = ipsA
@@ -164,18 +166,17 @@ func (rbl *Rbl) lookup(rblList string, targetHost string) []Rblresult {
 	return rbl.Results
 }
 
-// Update runs the checks for an against against all "rbls"
+// Update runs the checks for an IP against against all "rbls"
 func (rbl *Rbl) Update(ip string, rbls []string) {
 	// from: godnsbl
 	wg := &sync.WaitGroup{}
 
 	for _, source := range rbls {
-
 		wg.Add(1)
 		go func(source string, ip string) {
 			defer wg.Done()
 
-			log.Debugf("Working blacklist %s", source)
+			log.Debugf("Working blacklist %s (ip: %s)", source, ip)
 
 			results := rbl.lookup(source, ip)
 			if len(results) == 0 {

--- a/collector/rbl_test.go
+++ b/collector/rbl_test.go
@@ -1,0 +1,20 @@
+package collector
+
+import (
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestUpdate(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	log.SetOutput(os.Stdout)
+
+	rbl := NewRbl("0.0.0.0:53")
+	rbl.Update("this.is.not.an.ip", []string{"cbl.abuseat.org"})
+
+	if len(rbl.Results) > 0 {
+		t.Errorf("Got a result, but shouldn't have: %v", rbl.Results)
+	}
+}


### PR DESCRIPTION
If the IP address is neither v4 or v6, `IP.ParseIP()` returns `nil`.

Related: Luzilla/dnsbl_exporter#64