### PR TITLE
Add support for domain based blacklists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,14 @@ run-dev:
 		--log.debug \
 		--config.dns-resolver 0.0.0.0:15353
 
+.PHONY: run-dev-domain
+run-dev-domain:
+	go run dnsbl_exporter.go \
+		--log.debug \
+		--config.rbls ./rbls-domain.ini \
+		--config.domain-based \
+		--config.dns-resolver 0.0.0.0:15353
+
 .PHONY: snapshot
 snapshot:
 	goreleaser build --snapshot --clean

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ dnsbl-exporter -h
 --config.dns-resolver value  IP address of the resolver to use. (default: "127.0.0.1:53")
 --config.rbls value          Configuration file which contains RBLs (default: "./rbls.ini")
 --config.targets value       Configuration file which contains the targets to check. (default: "./targets.ini")
+--config.domain-based        RBLS are domain instead of IP based blacklists (default: false)
 --web.listen-address value   Address to listen on for web interface and telemetry. (default: ":9211")
 --web.telemetry-path value   Path under which to expose metrics. (default: "/metrics")
 --log.debug                  Enable more output in the logs, otherwise INFO.
@@ -84,6 +85,8 @@ luzilla_rbls_ips_blacklisted{hostname="mail.gmx.net",ip="212.227.17.168",rbl="ix
 ```
 
 This represent the server's hostname and the DNSBL in question. `0` for unlisted and `1` for listed. Requests to the DNSBL happen in real-time and are not cached. Take this into account and use accordingly.
+
+If the exporter is configured for DNS based blacklists, the ip label represents the return code of the blacklist.
 
 ### Caveat
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -10,50 +10,89 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCollector(t *testing.T) {
+func TestCollectorSuite(t *testing.T) {
 	dnsMock := tests.CreateDNSMock(t)
 	defer dnsMock.Close()
-
 	logger := tests.CreateTestLogger(t)
 	util := tests.CreateDNSUtil(t, dnsMock.LocalAddr())
-	rbls := []string{"zen.spamhaus.org", "cbl.abuseat.org"}
-	targets := []string{
-		"79.214.198.85",  // bad
-		"relay.heise.de", // good
-		"1.3.3.7",        // good
-	}
 
-	c := collector.NewRblCollector(rbls, targets, util, logger)
+	t.Run("test=ip-based", func(t *testing.T) {
+		rbls := []string{"zen.spamhaus.org", "cbl.abuseat.org"}
+		targets := []string{
+			"79.214.198.85",  // bad
+			"relay.heise.de", // good
+			"1.3.3.7",        // good
+		}
 
-	result, err := testutil.CollectAndLint(c)
-	assert.Empty(t, result)
-	assert.NoError(t, err)
+		c := collector.NewRblCollector(rbls, targets, false, util, logger)
 
-	// take all metrics but duration as it's value is hardly predictable
-	metrics := []string{}
-	for _, metric := range []string{"used", "ips_blacklisted", "errors", "listed", "targets"} {
-		metrics = append(metrics, collector.BuildFQName(metric))
-	}
-	expected := `
-    # HELP luzilla_rbls_ips_blacklisted Blacklisted IPs
-    # TYPE luzilla_rbls_ips_blacklisted gauge
-    luzilla_rbls_ips_blacklisted{hostname="1.3.3.7",ip="1.3.3.7",rbl="cbl.abuseat.org"} 0
-    luzilla_rbls_ips_blacklisted{hostname="1.3.3.7",ip="1.3.3.7",rbl="zen.spamhaus.org"} 0
-    luzilla_rbls_ips_blacklisted{hostname="79.214.198.85",ip="79.214.198.85",rbl="cbl.abuseat.org"} 0
-    luzilla_rbls_ips_blacklisted{hostname="79.214.198.85",ip="79.214.198.85",rbl="zen.spamhaus.org"} 1
-    luzilla_rbls_ips_blacklisted{hostname="relay.heise.de",ip="193.99.145.50",rbl="cbl.abuseat.org"} 0
-    luzilla_rbls_ips_blacklisted{hostname="relay.heise.de",ip="193.99.145.50",rbl="zen.spamhaus.org"} 0
-    # HELP luzilla_rbls_listed The number of listings in RBLs (this is bad)
-    # TYPE luzilla_rbls_listed gauge
-    luzilla_rbls_listed{rbl="cbl.abuseat.org"} 0
-    luzilla_rbls_listed{rbl="zen.spamhaus.org"} 1
-    # HELP luzilla_rbls_targets The number of targets that are being probed (configured via targets.ini or ?target=)
-    # TYPE luzilla_rbls_targets gauge
-    luzilla_rbls_targets 3
-    # HELP luzilla_rbls_used The number of RBLs to check IPs against (configured via rbls.ini)
-    # TYPE luzilla_rbls_used gauge
-    luzilla_rbls_used 2
-  `
-	err = testutil.CollectAndCompare(c, strings.NewReader(expected), metrics...)
-	assert.NoError(t, err)
+		result, err := testutil.CollectAndLint(c)
+		assert.Empty(t, result)
+		assert.NoError(t, err)
+
+		// take all metrics but duration as it's value is hardly predictable
+		metrics := []string{}
+		for _, metric := range []string{"used", "ips_blacklisted", "errors", "listed", "targets"} {
+			metrics = append(metrics, collector.BuildFQName(metric))
+		}
+		expected := `
+      # HELP luzilla_rbls_ips_blacklisted Blacklisted IPs
+      # TYPE luzilla_rbls_ips_blacklisted gauge
+      luzilla_rbls_ips_blacklisted{hostname="1.3.3.7",ip="1.3.3.7",rbl="cbl.abuseat.org"} 0
+      luzilla_rbls_ips_blacklisted{hostname="1.3.3.7",ip="1.3.3.7",rbl="zen.spamhaus.org"} 0
+      luzilla_rbls_ips_blacklisted{hostname="79.214.198.85",ip="79.214.198.85",rbl="cbl.abuseat.org"} 0
+      luzilla_rbls_ips_blacklisted{hostname="79.214.198.85",ip="79.214.198.85",rbl="zen.spamhaus.org"} 1
+      luzilla_rbls_ips_blacklisted{hostname="relay.heise.de",ip="193.99.145.50",rbl="cbl.abuseat.org"} 0
+      luzilla_rbls_ips_blacklisted{hostname="relay.heise.de",ip="193.99.145.50",rbl="zen.spamhaus.org"} 0
+      # HELP luzilla_rbls_listed The number of listings in RBLs (this is bad)
+      # TYPE luzilla_rbls_listed gauge
+      luzilla_rbls_listed{rbl="cbl.abuseat.org"} 0
+      luzilla_rbls_listed{rbl="zen.spamhaus.org"} 1
+      # HELP luzilla_rbls_targets The number of targets that are being probed (configured via targets.ini or ?target=)
+      # TYPE luzilla_rbls_targets gauge
+      luzilla_rbls_targets 3
+      # HELP luzilla_rbls_used The number of RBLs to check IPs against (configured via rbls.ini)
+      # TYPE luzilla_rbls_used gauge
+      luzilla_rbls_used 2
+    `
+		err = testutil.CollectAndCompare(c, strings.NewReader(expected), metrics...)
+		assert.NoError(t, err)
+	})
+
+	t.Run("test=domain-based", func(t *testing.T) {
+		rbls := []string{"dbl.spamhaus.org"}
+		targets := []string{
+			"dbltest.com", // bad
+			"example.com", // good
+		}
+
+		c := collector.NewRblCollector(rbls, targets, true, util, logger)
+
+		result, err := testutil.CollectAndLint(c)
+		assert.Empty(t, result)
+		assert.NoError(t, err)
+
+		// take all metrics but duration as it's value is hardly predictable
+		metrics := []string{}
+		for _, metric := range []string{"used", "ips_blacklisted", "errors", "listed", "targets"} {
+			metrics = append(metrics, collector.BuildFQName(metric))
+		}
+		expected := `
+			# HELP luzilla_rbls_ips_blacklisted Blacklisted IPs
+			# TYPE luzilla_rbls_ips_blacklisted gauge
+			luzilla_rbls_ips_blacklisted{hostname="dbltest.com",ip="127.0.1.2",rbl="dbl.spamhaus.org"} 1
+			luzilla_rbls_ips_blacklisted{hostname="example.com",ip="",rbl="dbl.spamhaus.org"} 0
+			# HELP luzilla_rbls_listed The number of listings in RBLs (this is bad)
+			# TYPE luzilla_rbls_listed gauge
+			luzilla_rbls_listed{rbl="dbl.spamhaus.org"} 1
+			# HELP luzilla_rbls_targets The number of targets that are being probed (configured via targets.ini or ?target=)
+			# TYPE luzilla_rbls_targets gauge
+			luzilla_rbls_targets 2
+			# HELP luzilla_rbls_used The number of RBLs to check IPs against (configured via rbls.ini)
+			# TYPE luzilla_rbls_used gauge
+			luzilla_rbls_used 1
+    `
+		err = testutil.CollectAndCompare(c, strings.NewReader(expected), metrics...)
+		assert.NoError(t, err)
+	})
 }

--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -10,9 +10,10 @@ import (
 )
 
 type ProberHandler struct {
-	DNS    *dns.DNSUtil
-	Rbls   []string
-	Logger *slog.Logger
+	DNS         *dns.DNSUtil
+	Rbls        []string
+	DomainBased bool
+	Logger      *slog.Logger
 }
 
 func (p ProberHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -26,7 +27,7 @@ func (p ProberHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	targets = append(targets, r.URL.Query().Get("target"))
 
 	registry := setup.CreateRegistry()
-	collector := setup.CreateCollector(p.Rbls, targets, p.DNS, p.Logger)
+	collector := setup.CreateCollector(p.Rbls, targets, p.DomainBased, p.DNS, p.Logger)
 	registry.MustRegister(collector)
 
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -7,8 +7,8 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-func CreateCollector(rbls []string, targets []string, dnsUtil *dns.DNSUtil, logger *slog.Logger) *collector.RblCollector {
-	return collector.NewRblCollector(rbls, targets, dnsUtil, logger)
+func CreateCollector(rbls []string, targets []string, domainBased bool, dnsUtil *dns.DNSUtil, logger *slog.Logger) *collector.RblCollector {
+	return collector.NewRblCollector(rbls, targets, domainBased, dnsUtil, logger)
 }
 
 func CreateRegistry() *prometheus.Registry {

--- a/internal/tests/tests.go
+++ b/internal/tests/tests.go
@@ -54,6 +54,13 @@ func CreateDNSMock(t *testing.T) *mockdns.Server {
 		"10.0.0.127.zen.spamhaus.org.": {
 			TXT: []string{"https://www.spamhaus.org/query/ip/127.0.0.10"},
 		},
+		// domain based rbl responses
+		// https://www.spamhaus.org/faq/section/Spamhaus%20DBL#277
+		"dbltest.com.dbl.spamhaus.org.": {
+			A:   []string{"127.0.1.2"},
+			TXT: []string{"https://www.spamhaus.org/query/domain/dbltest.com"},
+		},
+		"example.com.dbl.spamhaus.org.": {},
 	}, true)
 	if err != nil {
 		assert.FailNow(t, "failed building mock", "error: %s", err)

--- a/rbls-domain.ini
+++ b/rbls-domain.ini
@@ -1,0 +1,2 @@
+[rbl]
+server=dbl.spamhaus.org

--- a/targets.ini
+++ b/targets.ini
@@ -6,3 +6,4 @@ server=smtp.gmail.com
 server=mail.gmx.net
 server=smtp.yahoo.com
 server=smtp.fastmail.com
+server=dbltest.com


### PR DESCRIPTION
This PR implements support for domain based blacklists as mentioned in https://github.com/Luzilla/dnsbl_exporter/issues/167.

The PR is based on https://github.com/Luzilla/dnsbl_exporter/pull/193

For usage see Readme and Makefile target `run-dev-domain`.