### PR TITLE
Feat: use scratch base for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
-FROM debian:stable-slim
+FROM scratch
 
 # nobody / nogroup
 ARG DNSBL_USER=65534
 ARG DNSBL_GROUP=65534
 
-ENV DNSBL_EXP_RESOLVER=ubound:53
-ENV DNSBL_EXP_RBLS=/etc/dnsbl-exporter/rbls.ini
-ENV DNSBL_EXP_TARGETS=/etc/dnsbl-exporter/targets.ini
-
-COPY dnsbl-exporter /usr/bin/
-
-RUN mkdir -p /etc/dnsbl-exporter
-COPY rbls.ini /etc/dnsbl-exporter/
-COPY targets.ini /etc/dnsbl-exporter/
-
-RUN chown -R $DNSBL_USER:$DNSBL_GROUP /etc/dnsbl-exporter
 USER $DNSBL_USER:$DNSBL_GROUP
+
+ENV DNSBL_EXP_RESOLVER=ubound:53
+ENV DNSBL_EXP_RBLS=/rbls.ini
+ENV DNSBL_EXP_TARGETS=/targets.ini
+
+COPY dnsbl-exporter rbls.ini targets.ini /
 
 EXPOSE 9211
 
-ENTRYPOINT ["/usr/bin/dnsbl-exporter"]
+ENTRYPOINT ["/dnsbl-exporter"]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Please note: `latest` is not provided.
 The images expect `target.ini` and `rbls.ini` in the following location:
 
 ```sh
-/etc/dnsbl-exporter
+/
 ```
 
 Either start the container and supply the contents, or build your own image:


### PR DESCRIPTION
Hi,

We built and pushed the image into our own registry. Where our trivy scanner discovered and complained about multiple CVEs. As is common with go binaries we can just use an image from scratch with just the binary and configuration files. This results in an image of about 8mb instead of 35mb and base image vulnerabilites or updates no longer exist.