### PR TITLE
Add ServiceMonitor Configuration

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dnsbl-exporter.fullname" . }}
+  labels:
+    {{- include "dnsbl-exporter.labels" . | nindent 4 }}
+spec:
+  endpoints:
+  - port: svc-9211
+    scheme: "http"
+    path: "/metrics"
+    interval: {{ .interval }}
+    scrapeTimeout: {{ .scrapeTimeout }}
+  jobLabel: "{{ template "dnsbl-exporter.fullname" $ }}"
+  selector:
+    matchLabels:
+      {{- include "dnsbl-exporter.selectorLabels" $ | nindent 6 }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -92,6 +92,11 @@ config:
     # --log.debug (enable debug level)
     debug: false
 
+serviceMonitor:
+  enabled: false
+  interval: 60s
+  scrapeTimeout: 20s
+
 # for demo purposes and mostly otherwise, a container with unbound in the same pod
 # if you disable this, you have to configure your own resolver
 unbound:


### PR DESCRIPTION
## Summary
- **Added**: `servicemonitor.yaml` template for ServiceMonitor resource.
- **Modified**: `deployment.yaml` to include YAML front matter.
- **Updated**: `values.yaml` to include ServiceMonitor configuration options.

## Details
- **deployment.yaml**:
  - Added YAML front matter (`---`) to the beginning of the file for proper YAML formatting.
  
- **values.yaml**:
  - Introduced a new `serviceMonitor` section with the following default values:
    - `enabled`: `false`
    - `interval`: `60s`
    - `scrapeTimeout`: `20s`
    
- **servicemonitor.yaml**:
  - New file created to define the ServiceMonitor resource for Prometheus monitoring.

These changes aim to enhance the monitoring capabilities of our deployments by optionally enabling ServiceMonitor configurations.

## Testing
- Ensure that the deployment works as expected without enabling the ServiceMonitor.
- Test enabling the ServiceMonitor and verify that it integrates correctly with Prometheus.

Please review the changes and provide feedback or approval for merging.
