### PR TITLE
Bump chart version to 0.1.1

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dnsbl-exporter
 description: A Helm chart to run dnsbl-exporter on Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.7.0-rc3"
 keywords:
 - prometheus


### PR DESCRIPTION
When I created https://github.com/Luzilla/dnsbl_exporter/pull/226 I forgot to update the chart version.