### PR TITLE
Add Config Checksum Annotation

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dnsbl-exporter
 description: A Helm chart to run dnsbl-exporter on Kubernetes
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.7.0-rc3"
 keywords:
 - prometheus

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -14,10 +14,11 @@ spec:
       {{- include "dnsbl-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "dnsbl-exporter.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}


### PR DESCRIPTION
## Summary
This merge request introduces a checksum annotation for the deployment template to ensure that changes in the ConfigMap trigger a pod restart.

## Changes
- **Chart.yaml**
  - Bumped chart version from `0.1.1` to `0.1.2`.
- **deployment.yaml**
  - Added `checksum/config` annotation to the pod template metadata to include a hash of the ConfigMap, ensuring that changes to the ConfigMap will trigger a pod restart.

## Context
- The addition of the checksum annotation in `deployment.yaml` helps maintain the integrity of the deployment by ensuring that any updates to the ConfigMap will result in the pods being restarted, thus applying the new configuration.

This update is crucial for maintaining the reliability and consistency of the dnsbl-exporter application running on Kubernetes.
