### PR TITLE
feat: allow custom serviceMonitor labels

### DIFF
--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "dnsbl-exporter.fullname" . }}
   labels:
     {{- include "dnsbl-exporter.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+
 spec:
   endpoints:
   - port: svc-9211

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -96,6 +96,7 @@ serviceMonitor:
   enabled: false
   interval: 60s
   scrapeTimeout: 20s
+  labels: {}
 
 # for demo purposes and mostly otherwise, a container with unbound in the same pod
 # if you disable this, you have to configure your own resolver


### PR DESCRIPTION
Hello,

There are cases where Prometheus watches which serviceMonitors to scrape based on custom labels, it will be useful to have that option in the helm-chart.

This is how the 'serviceMonitor' would look like with custom labels defined in values.yaml:

```yaml
serviceMonitor:
  enabled: false
  interval: 60s
  scrapeTimeout: 20s
  labels:
    prom-scrape: true
```