### PR TITLE
fix: read proper serviceMonitor settings from values.yaml

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dnsbl-exporter
 description: A Helm chart to run dnsbl-exporter on Kubernetes
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "v0.9.0"
 home: https://github.com/Luzilla/dnsbl_exporter
 sources:

--- a/chart/templates/servicemonitor.yaml
+++ b/chart/templates/servicemonitor.yaml
@@ -15,8 +15,8 @@ spec:
   - port: svc-9211
     scheme: "http"
     path: "/metrics"
-    interval: {{ .interval }}
-    scrapeTimeout: {{ .scrapeTimeout }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
   jobLabel: "{{ template "dnsbl-exporter.fullname" $ }}"
   selector:
     matchLabels:


### PR DESCRIPTION
'interval' and 'scrapeTimeout' were not read properly from values.yaml, causing the created resource to have empty values for both settings.