### PR TITLE
feat(release): build rpm, deb and sysext

### DIFF
--- a/.dalec/dalec.yml
+++ b/.dalec/dalec.yml
@@ -1,0 +1,130 @@
+# syntax=ghcr.io/azure/dalec/frontend:latest
+# yaml-language-server: $schema=https://raw.githubusercontent.com/project-dalec/dalec/v0.20.5/docs/spec.schema.json
+#
+# Unified Dalec spec for dnsbl-exporter
+# Supports RPM, DEB, and sysext output formats
+#
+# Build commands (ARCH_DIR: amd64_v1, arm64_v8.0):
+#   RPM:    docker build -f .dalec/dalec.yml --target=mariner2/rpm --build-arg VERSION=x.y.z --build-arg ARCH_DIR=amd64_v1 -o type=local,dest=./out .
+#   DEB:    docker build -f .dalec/dalec.yml --target=jammy/deb --build-arg VERSION=x.y.z --build-arg ARCH_DIR=amd64_v1 -o type=local,dest=./out .
+#   sysext: docker build -f .dalec/dalec.yml --target=azlinux3/testing/sysext --build-arg VERSION=x.y.z --build-arg ARCH_DIR=amd64_v1 -o type=local,dest=./out .
+#
+# Prerequisites:
+#   Run `goreleaser build --snapshot --clean` first to populate the dist/ directory
+#
+name: dnsbl-exporter
+version: ${VERSION}
+revision: "1"
+license: Apache-2.0
+vendor: Luzilla Capital GmbH
+packager: Luzilla Capital GmbH
+website: https://github.com/Luzilla/dnsbl_exporter
+description: Prometheus exporter for DNSBL (DNS-based Blackhole Lists). Monitors if your IPs or domains are listed on various DNSBLs.
+
+args:
+  VERSION: "0.0.0"
+  # Path to the prebuilt binary inside the build context (as emitted by GoReleaser).
+  BINARY_PATH: "dist/dnsbl_exporter_linux_arm64_v8.0/"
+
+sources:
+  goreleaser:
+    context: {}
+    path: ${BINARY_PATH}
+  service:
+    context: {}
+    path: .dalec/dnsbl-exporter.service
+  config:
+    context: {}
+    includes:
+      - rbls.ini
+      - rbls-domain.ini
+      - targets.ini
+
+artifacts:
+  groups:
+    - name: dnsbl-exporter
+  users:
+    - name: dnsbl-exporter
+  binaries:
+    goreleaser/dnsbl-exporter:
+      subpath: ""
+      permissions: 0o755
+      user: dnsbl-exporter
+      group: dnsbl-exporter
+  createDirectories:
+    config:
+      dnsbl-exporter:
+        mode: 0o755
+        user: dnsbl-exporter
+        group: dnsbl-exporter
+  systemd:
+    units:
+      service/dnsbl-exporter.service:
+        name: ""
+        enable: true
+        start: false
+  configFiles:
+    config/rbls.ini:
+      subpath: dnsbl-exporter
+      permissions: 0o644
+      user: dnsbl-exporter
+      group: dnsbl-exporter
+    config/rbls-domain.ini:
+      subpath: dnsbl-exporter
+      permissions: 0o644
+      user: dnsbl-exporter
+      group: dnsbl-exporter
+    config/targets.ini:
+      subpath: dnsbl-exporter
+      permissions: 0o644
+      user: dnsbl-exporter
+      group: dnsbl-exporter
+
+targets:
+  mariner2:
+    dependencies:
+      runtime:
+        systemd: {}
+  jammy:
+    dependencies:
+      runtime:
+        systemd: {}
+  noble:
+    dependencies:
+      runtime:
+        systemd: {}
+  bookworm:
+    dependencies:
+      runtime:
+        systemd: {}
+
+tests:
+  - name: exporter files
+    files:
+      /usr/bin/dnsbl-exporter:
+      /etc/dnsbl-exporter:
+        is_dir: true
+      /etc/dnsbl-exporter/rbls.ini:
+        contains:
+          - '[rbl]'
+      /etc/dnsbl-exporter/rbls-domain.ini:
+      /etc/dnsbl-exporter/targets.ini:
+        contains:
+          - '[targets]'
+      /usr/lib/systemd/system/dnsbl-exporter.service:
+        starts_with: '[Unit]'
+        contains:
+          - 'Description=DNSBL'
+          - 'WantedBy='
+
+  - name: units
+    steps:
+      - command: /usr/bin/dnsbl-exporter -v
+      - command: ls -lah /etc/dnsbl-exporter/
+      - command: ls -lah /etc/dnsbl-exporter/rbls.ini
+      - command: ls -lah /etc/dnsbl-exporter/rbls-domain.ini
+      - command: ls -lah /etc/dnsbl-exporter/targets.ini
+      - command: ls -lah /usr/lib/systemd/system/dnsbl-exporter.service
+
+image:
+  entrypoint: /usr/bin/dnsbl-exporter

--- a/.dalec/dnsbl-exporter.service
+++ b/.dalec/dnsbl-exporter.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=DNSBL Prometheus Exporter
+Documentation=https://github.com/Luzilla/dnsbl_exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=dnsbl-exporter
+Group=dnsbl-exporter
+ExecStart=/usr/bin/dnsbl-exporter \
+    --config.rbls=/etc/dnsbl-exporter/rbls.ini \
+    --config.targets=/etc/dnsbl-exporter/targets.ini
+Restart=on-failure
+RestartSec=5s
+
+# Hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+ReadOnlyPaths=/
+CapabilityBoundingSet=
+
+[Install]
+WantedBy=multi-user.target

--- a/.github/actions/run-dalec/action.yml
+++ b/.github/actions/run-dalec/action.yml
@@ -1,0 +1,76 @@
+name: 'run-dalec'
+description: 'An action to run and orchestrate dalec (with goreleaser builds)'
+inputs:
+  target:
+    description: 'Target'
+    required: true
+  version:
+    description: 'Version'
+    required: true
+  build-directory:
+    description: 'Build directory from goreleaser'
+    required: false
+    default: './dist'
+  output-path:
+    description: 'Output'
+    required: false
+    default: './out'
+outputs:
+  artifact:
+    description: 'Artifact produced (.rpm, .deb or .raw)'
+    value: ${{ steps.artifact-name.outputs.value }}
+  output-path:
+    description: 'Output path'
+    value: ${{ inputs.output-path }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        DIST: ${{ inputs.build-directory }}
+      run: |
+        if [ ! -d "${DIST}" ]; then
+          echo "Missing goreleaser directory"
+          exit 1
+        fi
+    - id: arch
+      shell: bash
+      env:
+        DIST: ${{ inputs.build-directory }}
+      run: |
+        goarch=$(dpkg --print-architecture)
+        binary_path=$(jq -r --arg a "$goarch" \
+          '.[] | select(.type=="Binary" and .goos=="linux" and .goarch==$a) | .path' \
+          ${DIST}/artifacts.json)
+        if [ -z "$binary_path" ]; then
+          echo "no linux/${goarch} binary in ${DIST}/artifacts.json" >&2
+          exit 1
+        fi
+        binary_dir="$(dirname "$binary_path")/"
+        echo "goarch=$goarch" >> "$GITHUB_OUTPUT"
+        echo "binary-path=$binary_dir" >> "$GITHUB_OUTPUT"
+    - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+    - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      with:
+        context: .
+        file: ./.dalec/dalec.yml
+        target: ${{ inputs.target }}
+        build-args: |
+          VERSION=${{ inputs.version }}
+          BINARY_PATH=${{ steps.arch.outputs.binary-path }}
+        outputs: type=local,dest=${{ inputs.output-path }}
+      env:
+        DOCKER_BUILD_SUMMARY: false
+        DOCKER_BUILD_RECORD_UPLOAD: false
+    - id: artifact-name
+      env:
+        OUT: ${{ inputs.output-path }}
+      shell: bash
+      run: |
+        name=$(find ${OUT} -type f \( -name '*.deb' -o -name '*.rpm' -o -name '*.raw' \) ! -name '*.src.rpm' -printf '%f\n' | head -1)
+        if [ -z "$name" ]; then
+          echo "no package file found in ${OUT}" >&2
+          ls -la ${OUT} >&2
+          exit 1
+        fi
+        echo "value=$name" >> $GITHUB_OUTPUT

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,9 @@ updates:
     cooldown:
       default-days: 7
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
     groups:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,10 +29,10 @@ jobs:
       with:
         persist-credentials: false
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
     - name: Autobuild
-      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Copy .ini files
       run: cp targets.ini rbls.ini ./dist/dnsbl_exporter_linux_amd64_v1
     - name: Upload artifact
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: dnsbl_exporter
         path: dist/dnsbl_exporter_linux_amd64_v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,8 +7,7 @@ concurrency:
   group: pr-${{ github.event.number }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check:
@@ -24,6 +23,7 @@ jobs:
       - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
 
   build_unbound:
+    needs: check
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,11 +38,14 @@ jobs:
       run: |
         IMAGE_NAME=$(uuidgen)
         echo "name=ttl.sh/${IMAGE_NAME}:1h" >> $GITHUB_OUTPUT
-    - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+    - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: .docker/unbound/rootfs
         push: true
         tags: ${{ steps.image.outputs.name }}
+      env:
+        DOCKER_BUILD_SUMMARY: false
+        DOCKER_BUILD_RECORD_UPLOAD: false
     - if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
       with:
@@ -50,17 +53,25 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - if: github.event.pull_request.head.repo.full_name == github.repository
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: .docker/unbound/rootfs
         push: true
         tags: ghcr.io/luzilla/unbound:dev
+      env:
+        DOCKER_BUILD_SUMMARY: false
+        DOCKER_BUILD_RECORD_UPLOAD: false
 
   test:
+    needs: check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
-        go-version: [1.25.x]
-    runs-on: ubuntu-latest
+        go-version:
+          - 1.25.x
+          - 1.26.x
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
@@ -69,15 +80,20 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
         cache: false
-    - run: go test ./...
+    - run: go test -v --race ./...
 
   release_test:
     needs: test
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
+        fetch-depth: 0
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
@@ -89,9 +105,99 @@ jobs:
       with:
         version: '~> v2'
         args: release --snapshot --clean
+    - id: version
+      run: |
+        version=$(jq -r '.tag | ltrimstr("v")' dist/metadata.json)
+        echo "version=${version}" >> $GITHUB_OUTPUT
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: dist
+        path: dist/
+        retention-days: 1
+        if-no-files-found: error
+
+  package_test:
+    needs: release_test
+    name: package-${{ matrix.target }}-${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        target:
+          - mariner2/rpm
+          - bookworm/deb
+          - azlinux3/testing/sysext
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - id: dalec
+        uses: ./.github/actions/run-dalec
+        with:
+          target: ${{ matrix.target }}
+          version: ${{ needs.release_test.outputs.version }}
+          build-directory: ./dist
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.dalec.outputs.artifact }}
+          path: ${{ steps.dalec.outputs.output-path }}
+          retention-days: 2
+          if-no-files-found: error
+
+  smoke_test_ubuntu:
+    needs: package_test
+    runs-on: ${{ matrix.runner }}
+    permissions: {}
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: "dnsbl-exporter_*${{ matrix.arch }}.deb"
+          merge-multiple: true
+      - env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          sudo apt update -y
+          sudo apt install -y ./dnsbl-exporter_*${ARCH}.deb
+      - name: test install
+        run: |
+          command -v dnsbl-exporter
+          dnsbl-exporter -h
+      - name: test user/group
+        run: |
+          getent passwd dnsbl-exporter
+          getent group  dnsbl-exporter
+      - name: test service
+        run: |
+          systemctl cat dnsbl-exporter.service
+      - name: test config files
+        run: |
+          test -f /etc/dnsbl-exporter/rbls.ini
+          test -f /etc/dnsbl-exporter/rbls-domain.ini
+          test -f /etc/dnsbl-exporter/targets.ini
 
   freebsd:
+    needs:
+      - check
+      - test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         version:
@@ -110,12 +216,24 @@ jobs:
         run: uname -a
     - name: install build dependencies
       shell: freebsd {0}
-      run: pkg install -y lang/go git-lite devel/goreleaser sysutils/helm
+      run: |
+        pkg install -y \
+          lang/go \
+          git-lite \
+          devel/goreleaser \
+          sysutils/helm
     - name: download source
       shell: freebsd {0}
       run: git clone https://github.com/${{ github.repository }}
     - name: build
       shell: freebsd {0}
-      run: cd dnsbl_exporter && goreleaser build --single-target --snapshot --clean
+      run: |
+        cd dnsbl_exporter && \
+        goreleaser build \
+          --single-target \
+          --snapshot \
+          --clean
     - shell: freebsd {0}
-      run: cd dnsbl_exporter && ./dist/dnsbl_exporter_freebsd_amd64_v1/dnsbl-exporter -h
+      run: |
+        cd dnsbl_exporter && \
+        ./dist/dnsbl_exporter_freebsd_amd64_v1/dnsbl-exporter -h

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           type=ref,event=branch
           type=ref,event=pr
           type=semver,pattern={{raw}}
-    - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+    - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: .docker/unbound/rootfs
         push: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-dist
-vendor
-.envrc
+/dist
+/out
+/vendor
+/.envrc

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ snapshot:
 
 .PHONY: test
 test:
-	act "pull_request"
+	go test -v --race ./...
 
 .PHOMY: test-deploy-helm
 test-deploy-helm:
@@ -47,3 +47,43 @@ build-unbound:
 	docker build \
 		-t ghcr.io/luzilla/unbound:dev \
 		.docker/unbound/rootfs
+
+# Dalec package builds (requires goreleaser snapshot first)
+VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.0.0")
+# GoReleaser arch directory suffix: amd64_v1, arm64_v8.0
+ARCH_DIR     ?= amd64_v1
+BINARY_PATH  ?= dist/dnsbl_exporter_linux_$(ARCH_DIR)/dnsbl-exporter
+
+DALEC_TARGETS ?= mariner2/rpm jammy/deb noble/deb bookworm/deb azlinux3/testing/sysext
+DALEC_TARGET  ?= mariner2/rpm
+
+dalec_out = $(lastword $(subst /, ,$(1)))
+
+.PHONY: dalec
+dalec:
+	$(info Building $(DALEC_TARGET) for $(VERSION) ($(BINARY_PATH)))
+	docker build -f .dalec/dalec.yml \
+		--platform=linux/amd64 \
+		--target=$(DALEC_TARGET) \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg BINARY_PATH=$(BINARY_PATH) \
+		-o type=local,dest=./out/$(call dalec_out,$(DALEC_TARGET)) .
+
+.PHONY: dalec-all
+dalec-all: snapshot
+	@for t in $(DALEC_TARGETS); do \
+		$(MAKE) dalec DALEC_TARGET=$$t || exit 1; \
+	done
+
+.PHONY: dalec-debug
+dalec-debug:
+	@docker run --rm -v "$(CURDIR)/out/sysext:/sysext" alpine:latest sh -c '\
+		apk add -q erofs-utils && \
+		for f in /sysext/*.raw; do \
+			echo "=== $$f ==="; \
+			dump.erofs --ls "$$f"; \
+			echo "--- extension-release ---"; \
+			fsck.erofs --extract=/tmp/x "$$f" >/dev/null && \
+			cat /tmp/x/usr/lib/extension-release.d/extension-release.* ; \
+			rm -rf /tmp/x; \
+		done'

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,5 +5,8 @@
   - [DNS](./dns.md)
   - [Operation Modes](./operation-modes.md)
   - [Alerting](./alerting.md)
-- [Deployment](./deployment.md)
+- [Deployment](./deployment/index.md)
+  - [Standalone](./deployment/standalone.md)
+  - [Packages](./deployment/packages.md)
+  - [Container](./deployment/container.md)
 

--- a/docs/src/deployment/brew.md
+++ b/docs/src/deployment/brew.md
@@ -1,0 +1,4 @@
+# Brew
+
+> [!NOTE]
+> Coming soon.

--- a/docs/src/deployment/container.md
+++ b/docs/src/deployment/container.md
@@ -1,21 +1,4 @@
-# Deployment
-
-The `dnsbl-exporter` can be deployed as a stand-alone binary, container or on Kubernetes using Helm.
-
-## Standalone binary
-
-_Releases are available for Mac, Linux and FreeBSD._
-
- 1. Go to [release](https://github.com/Luzilla/dnsbl_exporter/releases) and download a release for your platform.
- 1. Get `rbls.ini` and put it next to the binary.
- 1. Get `targets.ini`, and customize. Or use the defaults.
- 1. `./dnsbl-exporter`
-
- Go to `http://127.0.0.1:9211/` in your browser.
-
- As option you can configure exporter to run as `systemd` service.
-
-## Container
+# Container
 
 Docker/OCI images are available in the [container registry](https://github.com/orgs/Luzilla/packages?repo_name=dnsbl_exporter):
 
@@ -24,7 +7,10 @@ $ docker pull ghcr.io/luzilla/dnsbl_exporter:vX.Y.Z
 ...
 ```
 
-> **Please note:** The `latest` is not provided. Pick an explicit version.
+The image works with podman and docker as the exporter runs rootless (user `nobody`).
+
+> [!CAUTION]
+> The `latest` tag is not provided. Please pick an explicit version.
 
 The images expect `target.ini` and `rbls.ini` in the following location:
 
@@ -54,8 +40,12 @@ ADD my-rbls.ini /rbls.ini
 
 Additionally, a helm chart is provided to run the `dnsbl-exporter` on Kubernetes.
 
-To get started quickly, an unbound container is installed into the pod alongside the exporter.
-This unbound acts as a local DNS server to send queries to. You may turn this off with `unbound.enabled=false` and provide your own resolver (via `config.resolver: an.ip.address:port`).
+To get started quickly, an unbound container is included as a sidecar in the pod alongside the exporter.
+
+This unbound acts as a local DNS server to send queries to.
+
+> [!TIP]
+> To disable the included, use `unbound.enabled=false` and provide your own resolver (via `config.resolver: an.ip.address:port`).
 
 To configure the chart, copy [`chart/values.yaml`](https://github.com/Luzilla/dnsbl_exporter/blob/main/chart/values.yaml) to `values.local.yaml`.
 
@@ -67,6 +57,9 @@ dependencies:
     repository: oci://ghcr.io/luzilla/charts
     version: 0.1.0
 ```
+
+> [!CAUTION]
+> Please adjust the chart version.
 
 The sources for the helm chart are in [chart](https://github.com/Luzilla/dnsbl_exporter/tree/main/chart), to install it, you can inspect the `Chart.yaml` for the version, check the [helm chart repository](https://github.com/orgs/Luzilla/packages/container/package/charts%2Fdnsbl-exporter) or check out [artifact hub](https://artifacthub.io/packages/helm/luzilla/dnsbl-exporter).
 

--- a/docs/src/deployment/index.md
+++ b/docs/src/deployment/index.md
@@ -1,0 +1,7 @@
+# Deployment
+
+The `dnsbl-exporter` can be deployed (or installed) as a stand-alone binary, container or on Kubernetes using Helm.
+
+- [standalone](./deployment/standalone.md)
+- [packages (deb, rpm, sysext)](./deployment/packages.md)
+- [container](./deployment/container.md)

--- a/docs/src/deployment/packages.md
+++ b/docs/src/deployment/packages.md
@@ -1,0 +1,18 @@
+# packages
+
+> [!TIP]
+> New in version `v0.13.0`.
+
+Each (GitHub) release also contains:
+
+ - rpm
+ - deb (jammy, noble, bookworm)
+ - sysext
+
+The package will setup default configuration in `/etc/dnsbl-exporter` and includes a systemd unit to manage the exporter as well.
+
+```bash
+$ systemctl enable dnsbl-exporter
+$ systemctl start dnsbl-exporter
+$ systemctl status dnsbl-exporter
+```

--- a/docs/src/deployment/standalone.md
+++ b/docs/src/deployment/standalone.md
@@ -1,0 +1,20 @@
+# Standalone
+
+_Releases are available for Mac, Linux and FreeBSD._
+
+ 1. Go to [release](https://github.com/Luzilla/dnsbl_exporter/releases) and download a binary for your system/platform.
+ 1. Get `rbls.ini` and put it next to the binary.
+ 1. Get `targets.ini`, and customize. Or use the defaults.
+ 1. `./dnsbl-exporter`
+
+> [!TIP]
+> Example config files are provided on [GitHub](https://github.com/Luzilla/dnsbl-exporter).
+
+Go to `http://127.0.0.1:9211/` in your browser.
+
+## Managing the exporter
+
+> [!TIP]
+> Check out [Packages](./packages.md).
+
+As option you can configure exporter to run as `systemd` service. Consider using a package instead.

--- a/docs/src/dns.md
+++ b/docs/src/dns.md
@@ -6,17 +6,19 @@ Using public resolvers such as Google, Cloudflare, OpenDNS, Quad9 etc. will like
 
 The recommendation is to setup a private resolver, such as [Unbound](https://github.com/NLnetLabs/unbound) without forwarding, which means you will use root NS.
 
+> [!IMPORTANT]
 > **Please note:** If you have local copy (mirror) of RBL zone synced over rsync or other channels you can configure local [`rbldnsd`](https://rbldnsd.io/) to serve this zone and configure Unbound query this zone from `rbldnsd`.
 
 To install unbound on a Mac, follow these steps:
 
-```sh
+```bash
 $ brew install unbound
 ...
 $ sudo unbound -d -vvvv
 ```
 
-> And leave the Terminal open — there will be ample queries and data for you to see and learn from.
+> [!TIP]
+> Leave the Terminal open — there will be ample queries and data for you to see and learn from.
 
 An alternative to Homebrew is to use Docker; an example image is provided in this repository, it
 contains a working configuration — ymmv.
@@ -27,7 +29,7 @@ docker run -p 53:5353/udp ghcr.io/luzilla/unbound:v0.7.0-rc3
 
 Verify Unbound works:
 
-```sh
+```bash
  $ dig +short @127.0.0.1 spamhaus.org
 192.42.118.104
 ```


### PR DESCRIPTION
this adds support for building various packages (rpm, deb and
sysext) to install the dnsbl_exporter on various operation systems
using a package manager.

the resulting package will also include a systemd unit file.

also updates workflows (version pins, permissions).

also runs the go tests against Go 1.26.x

resolves: https://github.com/Luzilla/dnsbl_exporter/issues/86