### PR TITLE
refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist
 /out
 /vendor
+/docs/reviews/
 /.envrc

--- a/app/app.go
+++ b/app/app.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Luzilla/dnsbl_exporter/pkg/dns"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/exp/slog"
+	"log/slog"
 
 	x "github.com/miekg/dns"
 )
@@ -142,9 +142,9 @@ func (a *DNSBLApp) Bootstrap() {
 
 		var logHandler slog.Handler
 		if cCtx.String("log.format") == "text" {
-			logHandler = handler.NewTextHandler(writer)
+			logHandler = slog.NewTextHandler(writer, handler)
 		} else {
-			logHandler = handler.NewJSONHandler(writer)
+			logHandler = slog.NewJSONHandler(writer, handler)
 		}
 
 		log := slog.New(logHandler)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -50,8 +50,8 @@ func NewRblCollector(rbls []string, targets []string, domainBased bool, util *dn
 		),
 		errorsMetrics: prometheus.NewDesc(
 			BuildFQName("errors"),
-			"The number of errors which occurred testing the RBLs",
-			[]string{"rbl"},
+			"Whether an error occurred while testing this target against the RBL (1) or not (0)",
+			[]string{"rbl", "ip", "hostname"},
 			nil,
 		),
 		listedMetric: prometheus.NewDesc(
@@ -164,16 +164,17 @@ func (c *RblCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 			labelValues := []string{check.Rbl, ip, check.Target.Host}
 
-			// this is an "error" from the RBL/transport
+			errorValue := 0.0
 			if check.Error {
 				c.logger.Error(check.ErrorType.Error(), slog.String("text", check.Text))
-				ch <- prometheus.MustNewConstMetric(
-					c.errorsMetrics,
-					prometheus.GaugeValue,
-					1,
-					[]string{check.Rbl}...,
-				)
+				errorValue = 1
 			}
+			ch <- prometheus.MustNewConstMetric(
+				c.errorsMetrics,
+				prometheus.GaugeValue,
+				errorValue,
+				labelValues...,
+			)
 
 			ch <- prometheus.MustNewConstMetric(
 				c.blacklistedMetric,

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Luzilla/dnsbl_exporter/pkg/ip"
 	"github.com/Luzilla/dnsbl_exporter/pkg/rbl"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 const namespace = "luzilla"

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1,13 +1,16 @@
 package collector_test
 
 import (
+	"net"
 	"strings"
 	"testing"
 
 	"github.com/Luzilla/dnsbl_exporter/collector"
 	"github.com/Luzilla/dnsbl_exporter/internal/tests"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCollectorSuite(t *testing.T) {
@@ -37,6 +40,18 @@ func TestCollectorSuite(t *testing.T) {
 			metrics = append(metrics, collector.BuildFQName(metric))
 		}
 		expected := `
+      # HELP luzilla_rbls_errors Whether an error occurred while testing this target against the RBL (1) or not (0)
+      # TYPE luzilla_rbls_errors gauge
+      luzilla_rbls_errors{hostname="1.3.3.5",ip="1.3.3.5",rbl="cbl.abuseat.org"} 0
+      luzilla_rbls_errors{hostname="1.3.3.5",ip="1.3.3.5",rbl="zen.spamhaus.org"} 0
+      luzilla_rbls_errors{hostname="1.3.3.6",ip="1.3.3.6",rbl="cbl.abuseat.org"} 0
+      luzilla_rbls_errors{hostname="1.3.3.6",ip="1.3.3.6",rbl="zen.spamhaus.org"} 0
+      luzilla_rbls_errors{hostname="1.3.3.7",ip="1.3.3.7",rbl="cbl.abuseat.org"} 0
+      luzilla_rbls_errors{hostname="1.3.3.7",ip="1.3.3.7",rbl="zen.spamhaus.org"} 0
+      luzilla_rbls_errors{hostname="79.214.198.85",ip="79.214.198.85",rbl="cbl.abuseat.org"} 0
+      luzilla_rbls_errors{hostname="79.214.198.85",ip="79.214.198.85",rbl="zen.spamhaus.org"} 0
+      luzilla_rbls_errors{hostname="relay.heise.de",ip="193.99.145.50",rbl="cbl.abuseat.org"} 0
+      luzilla_rbls_errors{hostname="relay.heise.de",ip="193.99.145.50",rbl="zen.spamhaus.org"} 0
       # HELP luzilla_rbls_ips_blacklisted Blacklisted IPs
       # TYPE luzilla_rbls_ips_blacklisted gauge
       luzilla_rbls_ips_blacklisted{hostname="1.3.3.5",ip="1.3.3.5",rbl="cbl.abuseat.org"} 0
@@ -83,6 +98,10 @@ func TestCollectorSuite(t *testing.T) {
 			metrics = append(metrics, collector.BuildFQName(metric))
 		}
 		expected := `
+			# HELP luzilla_rbls_errors Whether an error occurred while testing this target against the RBL (1) or not (0)
+			# TYPE luzilla_rbls_errors gauge
+			luzilla_rbls_errors{hostname="dbltest.com",ip="127.0.1.2",rbl="dbl.spamhaus.org"} 0
+			luzilla_rbls_errors{hostname="example.com",ip="",rbl="dbl.spamhaus.org"} 0
 			# HELP luzilla_rbls_ips_blacklisted Blacklisted IPs
 			# TYPE luzilla_rbls_ips_blacklisted gauge
 			luzilla_rbls_ips_blacklisted{hostname="dbltest.com",ip="127.0.1.2",rbl="dbl.spamhaus.org"} 1
@@ -100,4 +119,39 @@ func TestCollectorSuite(t *testing.T) {
 		err = testutil.CollectAndCompare(c, strings.NewReader(expected), metrics...)
 		assert.NoError(t, err)
 	})
+}
+
+// TestCollectorErrorsHaveUniqueLabelSets: when more than one target errors
+// against the same RBL in a single scrape, the `errors` series must stay
+// unique. Previously the metric only carried the `rbl` label, so two errors
+// against the same RBL produced duplicate label sets and Gather rather
+// "collected before with the same name and label values". The fix gives
+// `errors` the same `(rbl, ip, hostname)` shape as `ips_blacklisted`,
+// so each (target, rbl) pair is its own series.
+func TestCollectorErrorsHaveUniqueLabelSets(t *testing.T) {
+	// Bind a UDP socket and close it immediately so DNS queries to its
+	// address fail fast (connection refused via ICMP on localhost).
+	// Every lookup against the configured RBL hits the error branch in
+	// rbl.lookup, so two targets produce two error emissions for the same
+	// `rbl` label set.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	deadAddr := pc.LocalAddr()
+	require.NoError(t, pc.Close())
+
+	util := tests.CreateDNSUtil(t, deadAddr)
+	logger := tests.CreateTestLogger(t)
+
+	rbls := []string{"zen.spamhaus.org"}
+	// IP targets (no resolver step) so each one drives exactly one
+	// failing A-record lookup against the dead resolver.
+	targets := []string{"127.0.0.1", "127.0.0.2"}
+
+	c := collector.NewRblCollector(rbls, targets, false, util, logger)
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(c)
+
+	_, err = registry.Gather()
+	assert.NoError(t, err, "errors must produce one unique series per (target, rbl), not collide on the rbl label")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"errors"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 	"gopkg.in/ini.v1"
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Luzilla/dnsbl_exporter/config"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -38,7 +38,7 @@ func TestLoadConfig(t *testing.T) {
 		tc := tt
 		t.Run(tc.file, func(t *testing.T) {
 			c := &config.Config{
-				Logger: slog.New(slog.NewTextHandler(os.Stderr)),
+				Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
 			}
 			_, err := c.LoadFile(tc.file)
 			if tc.success {
@@ -52,7 +52,7 @@ func TestLoadConfig(t *testing.T) {
 
 func TestValidateConfig(t *testing.T) {
 	c := &config.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stderr)),
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
 	}
 
 	cfg, err := c.LoadFile("./../targets.ini")

--- a/docs/src/alerting.md
+++ b/docs/src/alerting.md
@@ -2,7 +2,11 @@
 
 The following example alerts use the available metrics from the exporter.
 
-## Prometheus
+## Listing
+
+To determine if your host/ip is listed, use one of the following.
+
+### Prometheus
 
 ```yaml
 alerts:
@@ -22,7 +26,7 @@ alerts:
 
 For more details, see the [Prometheus Alerting documentation](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
 
-## Prometheus Operator
+### Prometheus Operator
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -45,3 +49,24 @@ spec:
 ```
 
 For more details, see the [Operator Alerting documentation](https://prometheus-operator.dev/docs/user-guides/alerting/).
+
+## Errors
+
+> [!TIP]
+> New in `v0.13.0`.
+
+The exporter now returns a per-target `luzilla_rbls_errors` gauge with the
+same `(rbl, ip, hostname)` labels as `luzilla_rbls_ips_blacklisted`: `1` if
+the most recent check failed, `0` otherwise.
+
+To collapse it to one alert per RBL, aggregate to a scalar:
+
+```yaml
+- alert: DnsblRblErrors
+  expr: sum by (rbl)(luzilla_rbls_errors) > 0
+  for: 15m
+  labels:
+    severity: warning
+  annotations:
+    summary: RBL {{ $labels.rbl }} is returning errors
+``` 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
-	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	gopkg.in/ini.v1 v1.67.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72g=
-golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 h1:5llv2sWeaMSnA3w2kS57ouQQ4pudlXrR0dCgw51QK9o=
-golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Luzilla/dnsbl_exporter/internal/setup"
 	"github.com/Luzilla/dnsbl_exporter/pkg/dns"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type ProberHandler struct {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Luzilla/dnsbl_exporter/collector"
 	"github.com/Luzilla/dnsbl_exporter/pkg/dns"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 func CreateCollector(rbls []string, targets []string, domainBased bool, dnsUtil *dns.DNSUtil, logger *slog.Logger) *collector.RblCollector {

--- a/internal/tests/tests.go
+++ b/internal/tests/tests.go
@@ -8,14 +8,14 @@ import (
 	"github.com/Luzilla/dnsbl_exporter/pkg/dns"
 	"github.com/foxcpp/go-mockdns"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slog"
+	"log/slog"
 
 	x "github.com/miekg/dns"
 )
 
 func CreateTestLogger(t *testing.T) *slog.Logger {
 	t.Helper()
-	return slog.New(slog.NewTextHandler(os.Stderr))
+	return slog.New(slog.NewTextHandler(os.Stderr, nil))
 }
 
 func CreateDNSUtil(t *testing.T, resolver net.Addr) *dns.DNSUtil {

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -99,11 +100,24 @@ func (d *DNSUtil) GetTxtRecords(target string) (list []string, err error) {
 
 func (d *DNSUtil) makeQuery(msg *x.Msg) (*x.Msg, error) {
 	result, rt, err := d.client.Exchange(msg, net.JoinHostPort(d.resolver.host, d.resolver.port))
+	if err != nil {
+		return nil, err
+	}
+
 	d.logger.Debug("roundtrip",
 		slog.String("question", msg.Question[0].String()),
+		slog.String("rcode", x.RcodeToString[result.Rcode]),
 		slog.Float64("seconds", rt.Seconds())) // fixme -> histogram
 
-	return result, err
+	// RFC 5782: NOERROR + records means listed; NOERROR with no records or
+	// NXDOMAIN means not listed. Anything else (SERVFAIL, REFUSED, …) is an
+	// outage, not a clean check, and must surface as an error.
+	switch result.Rcode {
+	case x.RcodeSuccess, x.RcodeNameError:
+		return result, nil
+	default:
+		return result, fmt.Errorf("dns: %s", x.RcodeToString[result.Rcode])
+	}
 }
 
 func createQuestion(target string, record uint16) *x.Msg {

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	x "github.com/miekg/dns"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type DNSUtil struct {

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -1,12 +1,15 @@
 package dns_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/Luzilla/dnsbl_exporter/internal/tests"
 	"github.com/Luzilla/dnsbl_exporter/pkg/dns"
+	"github.com/foxcpp/go-mockdns"
 	x "github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDNSSuite(t *testing.T) {
@@ -17,8 +20,7 @@ func TestDNSSuite(t *testing.T) {
 		d := tests.CreateDNSUtil(t, dnsMock.LocalAddr())
 
 		aRecords, err := d.GetARecords("relay.heise.de")
-
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Greater(t, len(aRecords), 0)
 	})
 
@@ -29,8 +31,42 @@ func TestDNSSuite(t *testing.T) {
 		d := tests.CreateDNSUtil(t, dnsMock.LocalAddr())
 
 		txtRecords, err := d.GetTxtRecords("10.0.0.127.zen.spamhaus.org")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 1, len(txtRecords))
+	})
+}
+
+// TestRcodeAsError: a DNS response carrying a non-success rcode (SERVFAIL,
+// REFUSED, ...) must surface as an error so the `errors` metric fires.
+// Per RFC 5782, NXDOMAIN means "not listed" and must NOT surface as an
+// error.
+func TestRcodeAsError(t *testing.T) {
+	t.Run("servfail-surfaces-as-error", func(t *testing.T) {
+		// mockdns returns SERVFAIL when Zone.Err is non-nil.
+		srv, err := mockdns.NewServer(map[string]mockdns.Zone{
+			"broken.example.com.": {Err: errors.New("simulated outage")},
+		}, true)
+		require.NoError(t, err)
+		defer srv.Close()
+
+		d := tests.CreateDNSUtil(t, srv.LocalAddr())
+
+		_, err = d.GetARecords("broken.example.com")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SERVFAIL")
+	})
+
+	t.Run("nxdomain-stays-clean", func(t *testing.T) {
+		// Unknown names in the mock yield NXDOMAIN; per RFC 5782 that's
+		// "not listed", not an error.
+		dnsMock := tests.CreateDNSMock(t)
+		defer dnsMock.Close()
+
+		d := tests.CreateDNSUtil(t, dnsMock.LocalAddr())
+
+		records, err := d.GetARecords("not.in.mock.example.com")
+		require.NoError(t, err)
+		assert.Empty(t, records)
 	})
 }
 

--- a/pkg/rbl/rbl.go
+++ b/pkg/rbl/rbl.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Luzilla/dnsbl_exporter/pkg/dns"
 	"github.com/Luzilla/godnsbl"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // RblResult extends godnsbl and adds RBL name
@@ -67,7 +67,7 @@ func (r *RBL) lookup(blocklist string, target Target, c chan<- Result, logger *s
 
 	res, err := r.util.GetARecords(lookup)
 	if err != nil {
-		logger.Error("error occurred fetching A record", slog.String("msg", err.Error()))
+		logger.Error("error occurred fetching A record", slog.Any("err", err))
 
 		result.Error = true
 		result.ErrorType = err
@@ -87,7 +87,7 @@ func (r *RBL) lookup(blocklist string, target Target, c chan<- Result, logger *s
 
 	reason := net.ParseIP(res[0])
 	if reason == nil {
-		logger.Error("error getting (first) reason: %s", strings.Join(res, ", "))
+		logger.Error("error getting (first) reason", slog.String("answers", strings.Join(res, ", ")))
 		result.Error = true
 		result.ErrorType = fmt.Errorf("error getting the (first) reason: %s", strings.Join(res, ", "))
 		c <- result
@@ -106,7 +106,7 @@ func (r *RBL) lookup(blocklist string, target Target, c chan<- Result, logger *s
 		txt, err = r.util.GetTxtRecords(godnsbl.Reverse(reason) + "." + result.Rbl)
 	}
 	if err != nil {
-		logger.Error("error occurred fetching TXT record", slog.String("msg", err.Error()))
+		logger.Error("error occurred fetching TXT record", slog.Any("err", err))
 
 		result.Error = true
 		result.ErrorType = err

--- a/pkg/rbl/target.go
+++ b/pkg/rbl/target.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Luzilla/dnsbl_exporter/pkg/dns"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 type Target struct {
@@ -41,7 +41,7 @@ func (r *Resolver) Do(target string, c chan<- Target, done func()) {
 
 	ipsA, err := r.util.GetARecords(target)
 	if err != nil {
-		r.logger.Error("error fetching A-records for target", slog.String("msg", err.Error()))
+		r.logger.Error("error fetching A-records for target", slog.Any("err", err))
 		return
 	}
 


### PR DESCRIPTION
- **fix!: emit luzilla_rbls_errors per (rbl, ip, hostname)**
- **fix: surface non-success DNS rcodes as errors**
- **chore(slog)!: migrate from x/exp to stdlib log/slog**
